### PR TITLE
refactor: Upgrade image versions

### DIFF
--- a/nginx-proxy-2containers/letsencrypt-nginx-proxy-companion/Dockerfile
+++ b/nginx-proxy-2containers/letsencrypt-nginx-proxy-companion/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-alpine AS build-docker-gen
+FROM golang:1.15-alpine AS build-docker-gen
 
 ARG DOCKER_GEN_VERSION=0.7.4
 
@@ -19,7 +19,7 @@ RUN go get github.com/jwilder/docker-gen \
     && make get-deps \
     && make all
 
-FROM alpine:3.8
+FROM alpine:3.9
 
 LABEL maintainer="Nicolas Duchon <nicolas.duchon@gmail.com>"
 

--- a/nginx-proxy-2containers/nginx-proxy/Dockerfile
+++ b/nginx-proxy-2containers/nginx-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-alpine AS go-builder
+FROM golang:1.15-alpine AS go-builder
 
 ARG DOCKER_GEN_VERSION=0.7.4
 ARG FOREGO_VERSION=20180216151118

--- a/nginx-proxy-3containers/docker-gen/Dockerfile
+++ b/nginx-proxy-3containers/docker-gen/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-alpine AS build-docker-gen
+FROM golang:1.15-alpine AS build-docker-gen
 
 ARG DOCKER_GEN_VERSION=0.7.4
 

--- a/nginx-proxy-3containers/letsencrypt-nginx-proxy-companion/Dockerfile
+++ b/nginx-proxy-3containers/letsencrypt-nginx-proxy-companion/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-alpine AS build-docker-gen
+FROM golang:1.15-alpine AS build-docker-gen
 
 ARG DOCKER_GEN_VERSION=0.7.4
 
@@ -19,7 +19,7 @@ RUN go get github.com/jwilder/docker-gen \
     && make get-deps \
     && make all
 
-FROM alpine:3.8
+FROM alpine:3.9
 
 LABEL maintainer="Nicolas Duchon <nicolas.duchon@gmail.com>"
 


### PR DESCRIPTION
Hello @buchdag ,
Thank you for the great repo, with a few touches it worked like a charm on arm64 structure. 

There were two issue:
1 - There was a openssl version update after alpine:3.8, for now i just upgraded to 3.9 because latest gave some strange error.
2 - The second was one of golang deps used some new syntax only valid on golang 1.13, 

i have made required changes. If it looks good you can merge it.
