### PR TITLE
Switch to acme.sh based companion build

### DIFF
--- a/nginx-proxy-2containers/docker-compose.yaml
+++ b/nginx-proxy-2containers/docker-compose.yaml
@@ -30,6 +30,7 @@ services:
       - nginx-proxy
     volumes:
       - certs:/etc/nginx/certs:rw
+      - acme:/etc/acme.sh
       - /var/run/docker.sock:/var/run/docker.sock:ro
     network_mode: bridge
     restart: always
@@ -40,3 +41,4 @@ volumes:
   html:
   dhparam:
   certs:
+  acme:

--- a/nginx-proxy-2containers/letsencrypt-nginx-proxy-companion/Dockerfile
+++ b/nginx-proxy-2containers/letsencrypt-nginx-proxy-companion/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine AS build-docker-gen
+FROM golang:1.13-alpine AS build-docker-gen
 
 ARG DOCKER_GEN_VERSION=0.7.4
 

--- a/nginx-proxy-2containers/letsencrypt-nginx-proxy-companion/Dockerfile
+++ b/nginx-proxy-2containers/letsencrypt-nginx-proxy-companion/Dockerfile
@@ -45,12 +45,12 @@ RUN apk add --no-cache --virtual .bin-deps \
         socat
 
 # Install acme.sh and the letsencrypt service
-RUN mkdir /src \
+RUN mkdir /companion-src \
     && curl -sSL https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/archive/master.tar.gz \
-    | tar -C /src -xz \
-    && mv /src/docker-letsencrypt-nginx-proxy-companion-master/app /app \
-    && /src/docker-letsencrypt-nginx-proxy-companion-master/install_acme.sh \
-    && rm -rf /src
+    | tar -C /companion-src -xz \
+    && mv /companion-src/docker-letsencrypt-nginx-proxy-companion-master/app /app \
+    && /companion-src/docker-letsencrypt-nginx-proxy-companion-master/install_acme.sh \
+    && rm -rf /companion-src
 
 WORKDIR /app
 

--- a/nginx-proxy-2containers/letsencrypt-nginx-proxy-companion/Dockerfile
+++ b/nginx-proxy-2containers/letsencrypt-nginx-proxy-companion/Dockerfile
@@ -4,48 +4,52 @@ ARG DOCKER_GEN_VERSION=0.7.4
 
 LABEL stage=intermediate
 
-# Install build dependencies for docker-gen
-RUN apk add --update \
-	curl \
-	gcc \
-	git \
-	make \
-	musl-dev
-
-# Build docker-gen
-RUN go get github.com/jwilder/docker-gen \
+# Install build dependencies and build docker-gen
+RUN apk add --no-cache --virtual .build-deps \
+        curl \
+        gcc \
+        git \
+        make \
+        musl-dev \
+    && go get github.com/jwilder/docker-gen \
     && cd /go/src/github.com/jwilder/docker-gen \
-    && git checkout $DOCKER_GEN_VERSION \
+    && git -c advice.detachedHead=false checkout $DOCKER_GEN_VERSION \
     && make get-deps \
-    && make all
+    && make all \
+    && go clean -cache \
+    && mv docker-gen /usr/local/bin/ \
+    && rm -rf /go/src \
+    && apk del .build-deps
 
-FROM alpine:3.9
+FROM alpine:3.12
 
 LABEL maintainer="Nicolas Duchon <nicolas.duchon@gmail.com>"
 
-ENV DEBUG=false \
-    DOCKER_HOST=unix:///var/run/docker.sock
+ARG GIT_DESCRIBE
+ARG ACMESH_VERSION=2.8.8
 
-# Install curl
-RUN apk add --update curl \
-    && rm -rf /var/cache/apk/*
+ENV COMPANION_VERSION=$GIT_DESCRIBE \
+    DOCKER_HOST=unix:///var/run/docker.sock \
+    PATH=$PATH:/app
 
 # Copy docker-gen binary from build stage
-COPY --from=build-docker-gen /go/src/github.com/jwilder/docker-gen/docker-gen /usr/local/bin/
+COPY --from=build-docker-gen /usr/local/bin/docker-gen /usr/local/bin/
 
-# Install packages required by simp_le
-RUN apk add --update \
+# Install packages required by the image
+RUN apk add --no-cache --virtual .bin-deps \
         bash \
+        coreutils \
+        curl \
         jq \
         openssl \
-    && rm /var/cache/apk/*
+        socat
 
-# Install simp_le and the letsencrypt service
+# Install acme.sh and the letsencrypt service
 RUN mkdir /src \
-    && curl -sSL https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion/archive/master.tar.gz \
+    && curl -sSL https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/archive/master.tar.gz \
     | tar -C /src -xz \
     && mv /src/docker-letsencrypt-nginx-proxy-companion-master/app /app \
-    && /src/docker-letsencrypt-nginx-proxy-companion-master/install_simp_le.sh \
+    && /src/docker-letsencrypt-nginx-proxy-companion-master/install_acme.sh \
     && rm -rf /src
 
 WORKDIR /app

--- a/nginx-proxy-2containers/nginx-proxy/Dockerfile
+++ b/nginx-proxy-2containers/nginx-proxy/Dockerfile
@@ -26,7 +26,7 @@ RUN go get github.com/jwilder/docker-gen \
     && make get-deps \
     && make all
 
-FROM nginx:1.13-alpine
+FROM nginx:1.18-alpine
 
 LABEL maintainer="Nicolas Duchon <nicolas.duchon@gmail.com>"
 

--- a/nginx-proxy-2containers/nginx-proxy/Dockerfile
+++ b/nginx-proxy-2containers/nginx-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine AS go-builder
+FROM golang:1.13-alpine AS go-builder
 
 ARG DOCKER_GEN_VERSION=0.7.4
 ARG FOREGO_VERSION=20180216151118

--- a/nginx-proxy-3containers/docker-compose.yaml
+++ b/nginx-proxy-3containers/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   nginx:
-    image: nginx:alpine
+    image: nginx:1.18-alpine
     container_name: nginx-proxy
     ports:
       - "80:80"

--- a/nginx-proxy-3containers/docker-compose.yaml
+++ b/nginx-proxy-3containers/docker-compose.yaml
@@ -41,6 +41,7 @@ services:
       - nginx
     volumes:
       - certs:/etc/nginx/certs:rw
+      - acme:/etc/acme.sh
       - /var/run/docker.sock:/var/run/docker.sock:ro
     network_mode: bridge
     restart: always
@@ -50,3 +51,4 @@ volumes:
   vhost:
   html:
   certs:
+  acme:

--- a/nginx-proxy-3containers/docker-gen/Dockerfile
+++ b/nginx-proxy-3containers/docker-gen/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine AS build-docker-gen
+FROM golang:1.13-alpine AS build-docker-gen
 
 ARG DOCKER_GEN_VERSION=0.7.4
 

--- a/nginx-proxy-3containers/docker-gen/Dockerfile
+++ b/nginx-proxy-3containers/docker-gen/Dockerfile
@@ -19,7 +19,7 @@ RUN go get github.com/jwilder/docker-gen \
     && make get-deps \
     && make all
 
-FROM alpine:3.8
+FROM alpine:3.12
 
 LABEL maintainer="Nicolas Duchon <nicolas.duchon@gmail.com>"
 

--- a/nginx-proxy-3containers/docker-gen/Dockerfile
+++ b/nginx-proxy-3containers/docker-gen/Dockerfile
@@ -4,20 +4,22 @@ ARG DOCKER_GEN_VERSION=0.7.4
 
 LABEL stage=intermediate
 
-# Install build dependencies for docker-gen
-RUN apk add --update \
-	curl \
-	gcc \
-	git \
-	make \
-	musl-dev
-
-# Build docker-gen
-RUN go get github.com/jwilder/docker-gen \
+# Install build dependencies and build docker-gen
+RUN apk add --no-cache --virtual .build-deps \
+        curl \
+        gcc \
+        git \
+        make \
+        musl-dev \
+    && go get github.com/jwilder/docker-gen \
     && cd /go/src/github.com/jwilder/docker-gen \
-    && git checkout $DOCKER_GEN_VERSION \
+    && git -c advice.detachedHead=false checkout $DOCKER_GEN_VERSION \
     && make get-deps \
-    && make all
+    && make all \
+    && go clean -cache \
+    && mv docker-gen /usr/local/bin/ \
+    && rm -rf /go/src \
+    && apk del .build-deps
 
 FROM alpine:3.12
 
@@ -28,7 +30,7 @@ ENV DOCKER_GEN_VERSION=0.7.4 \
     DOCKER_HOST=unix:///tmp/docker.sock
 
 # Copy docker-gen binary from build stage
-COPY --from=build-docker-gen /go/src/github.com/jwilder/docker-gen/docker-gen /usr/local/bin/
+COPY --from=build-docker-gen /usr/local/bin/docker-gen /usr/local/bin/
 
 # Get latest nginx.tmpl
 ADD https://raw.githubusercontent.com/jwilder/nginx-proxy/master/nginx.tmpl /etc/docker-gen/templates/

--- a/nginx-proxy-3containers/letsencrypt-nginx-proxy-companion/Dockerfile
+++ b/nginx-proxy-3containers/letsencrypt-nginx-proxy-companion/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine AS build-docker-gen
+FROM golang:1.13-alpine AS build-docker-gen
 
 ARG DOCKER_GEN_VERSION=0.7.4
 

--- a/nginx-proxy-3containers/letsencrypt-nginx-proxy-companion/Dockerfile
+++ b/nginx-proxy-3containers/letsencrypt-nginx-proxy-companion/Dockerfile
@@ -45,12 +45,12 @@ RUN apk add --no-cache --virtual .bin-deps \
         socat
 
 # Install acme.sh and the letsencrypt service
-RUN mkdir /src \
+RUN mkdir /companion-src \
     && curl -sSL https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/archive/master.tar.gz \
-    | tar -C /src -xz \
-    && mv /src/docker-letsencrypt-nginx-proxy-companion-master/app /app \
-    && /src/docker-letsencrypt-nginx-proxy-companion-master/install_acme.sh \
-    && rm -rf /src
+    | tar -C /companion-src -xz \
+    && mv /companion-src/docker-letsencrypt-nginx-proxy-companion-master/app /app \
+    && /companion-src/docker-letsencrypt-nginx-proxy-companion-master/install_acme.sh \
+    && rm -rf /companion-src
 
 WORKDIR /app
 

--- a/nginx-proxy-3containers/letsencrypt-nginx-proxy-companion/Dockerfile
+++ b/nginx-proxy-3containers/letsencrypt-nginx-proxy-companion/Dockerfile
@@ -4,48 +4,52 @@ ARG DOCKER_GEN_VERSION=0.7.4
 
 LABEL stage=intermediate
 
-# Install build dependencies for docker-gen
-RUN apk add --update \
-	curl \
-	gcc \
-	git \
-	make \
-	musl-dev
-
-# Build docker-gen
-RUN go get github.com/jwilder/docker-gen \
+# Install build dependencies and build docker-gen
+RUN apk add --no-cache --virtual .build-deps \
+        curl \
+        gcc \
+        git \
+        make \
+        musl-dev \
+    && go get github.com/jwilder/docker-gen \
     && cd /go/src/github.com/jwilder/docker-gen \
-    && git checkout $DOCKER_GEN_VERSION \
+    && git -c advice.detachedHead=false checkout $DOCKER_GEN_VERSION \
     && make get-deps \
-    && make all
+    && make all \
+    && go clean -cache \
+    && mv docker-gen /usr/local/bin/ \
+    && rm -rf /go/src \
+    && apk del .build-deps
 
-FROM alpine:3.9
+FROM alpine:3.12
 
 LABEL maintainer="Nicolas Duchon <nicolas.duchon@gmail.com>"
 
-ENV DEBUG=false \
-    DOCKER_HOST=unix:///var/run/docker.sock
+ARG GIT_DESCRIBE
+ARG ACMESH_VERSION=2.8.8
 
-# Install curl
-RUN apk add --update curl \
-    && rm -rf /var/cache/apk/*
+ENV COMPANION_VERSION=$GIT_DESCRIBE \
+    DOCKER_HOST=unix:///var/run/docker.sock \
+    PATH=$PATH:/app
 
 # Copy docker-gen binary from build stage
-COPY --from=build-docker-gen /go/src/github.com/jwilder/docker-gen/docker-gen /usr/local/bin/
+COPY --from=build-docker-gen /usr/local/bin/docker-gen /usr/local/bin/
 
-# Install packages required by simp_le
-RUN apk add --update \
+# Install packages required by the image
+RUN apk add --no-cache --virtual .bin-deps \
         bash \
+        coreutils \
+        curl \
         jq \
         openssl \
-    && rm /var/cache/apk/*
+        socat
 
-# Install simp_le and the letsencrypt service
+# Install acme.sh and the letsencrypt service
 RUN mkdir /src \
-    && curl -sSL https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion/archive/master.tar.gz \
+    && curl -sSL https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/archive/master.tar.gz \
     | tar -C /src -xz \
     && mv /src/docker-letsencrypt-nginx-proxy-companion-master/app /app \
-    && /src/docker-letsencrypt-nginx-proxy-companion-master/install_simp_le.sh \
+    && /src/docker-letsencrypt-nginx-proxy-companion-master/install_acme.sh \
     && rm -rf /src
 
 WORKDIR /app


### PR DESCRIPTION
This PR fixes #7 by following the upstream `letsencrypt-nginx-proxy-companion` replacement of `simp_le` by `acme.sh`

However, please note that due to https://github.com/alpinelinux/docker-alpine/issues/135, image based on Alpine 3.13 and higher won't work on Raspbian without some reconfiguration of dockerd. This is due to Raspbian using and outdated `libseccomp` version, not because of a bug on Alpine's side.

To ensure compatibility with the vanilla 32 bits Raspbian, the `nginx:alpine` image has been set to version `1.18` and the `golang:alpine` image has been dowgraded to version `1.13`.

Please see https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.13.0#time64_requirements for more information.